### PR TITLE
[TMUX] Add focus-events on to config

### DIFF
--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -7,6 +7,7 @@ set -g mouse on
 set -g default-terminal 'tmux-256color'
 set -as terminal-overrides ",*:Tc"
 set -g allow-passthrough on
+set -g focus-events on
 set -ga update-environment TERM
 set -ga update-environment TERM_PROGRAM
 


### PR DESCRIPTION
Adds a simple option to let me focus on a window terminal without moving the cursor in vim. To do so I need to add FocusLost and FocusGained autocmd to basically turn off the mouse on lost focus so the first click is not registered and therefore only gives me focus back. I'm not sure if it still relevant, but apparently for (Neo)vim to correctly react to those events inside a tmux session, this option needs to be set.

A later PR will add those autocmd