### PR TITLE
[LAZYGIT] Add some custom commands to manage local branches

### DIFF
--- a/lazygit/.config/lazygit/config.yml
+++ b/lazygit/.config/lazygit/config.yml
@@ -2,3 +2,15 @@ git:
   paging:
     colorArg: always
     pager: diff-so-fancy
+
+customCommands:
+  - key: '<c-p>'
+    context: 'global'
+    command: 'git fetch -p'
+    description: 'Fetch and prune tracking branches'
+
+  - key: 'b'
+    context: 'localBranches'
+    loadingText: 'Pruning...'
+    command: "git branch -vv | awk '/: gone]/{print $1}' | xargs -r git branch -D"
+    description: 'Delete local branches with upstream gone'


### PR DESCRIPTION
This PR adds two custom commands to my general lazygit config:
- `Ctrl+p` as a global keybind that replaces the default one, but I never use the patch options anyway. This keybind simply calls `git fetch -p` to remove the tracking branches that have disappeared from upstream
- `b` in the local branches tab to remove any local branche for which the upstream is gone, which is a fairly common occurence after the previous command.

I could have combined the two because I rarely prune without removing the local branches immediately, but on the rare occasion I actually do need to keep the changes before deleting the branch, I'd rather keep them separated. Also, conceptually they don't do the same thing and should not be fused into one. To me that would be forming bad habits and forgetting that underneath there are multiple commands called in succession.